### PR TITLE
Treat missing isActive as 0 param

### DIFF
--- a/Sources/FeatureFlags/FeatureToggleMapper.swift
+++ b/Sources/FeatureFlags/FeatureToggleMapper.swift
@@ -39,10 +39,10 @@ class FeatureToggleMapper: FeatureToggleMappable {
     }
     
     func map(record: CKRecord) -> FeatureToggle? {
-        guard let isActive = record[featureToggleIsActiveFieldID] as? Int64, let featureName = record[featureToggleNameFieldID] as? String else {
+        guard let featureName = record[featureToggleNameFieldID] as? String else {
             return nil
         }
-        
+        let isActive = record[featureToggleIsActiveFieldID] as? Int64 ?? 0
         return FeatureToggle(identifier: featureName, isActive: NSNumber(value: isActive).boolValue)
     }
 }


### PR DESCRIPTION
## Problem: 

Cloudkit does not return the field `isActive` when 0. Features will never be turned off because processing is skipped.

## Fix:

Treat lack of isActive as `0`.

## Additional Info

Logs with isActive = 1
```
{
	creatorUserRecordID -> <CKRecordID: 0x281f2dba0; recordName=__defaultOwner__, zoneID=_defaultZone:__defaultOwner__>
	lastModifiedUserRecordID -> <CKRecordID: 0x281f2dc80; recordName=__defaultOwner__, zoneID=_defaultZone:__defaultOwner__>
	creationDate -> 2021-06-19 12:07:00 +0000
	modificationDate -> 2021-06-19 13:21:09 +0000
	modifiedByDevice -> 2
	featureName -> "test1"
	isActive -> 1 (type q)
}

```

Logs with isActive = 0
```
{
	creatorUserRecordID -> <CKRecordID: 0x28111cf60; recordName=__defaultOwner__, zoneID=_defaultZone:__defaultOwner__>
	lastModifiedUserRecordID -> <CKRecordID: 0x28111d120; recordName=__defaultOwner__, zoneID=_defaultZone:__defaultOwner__>
	creationDate -> 2021-06-19 12:07:00 +0000
	modificationDate -> 2021-06-19 13:24:54 +0000
	modifiedByDevice -> 2
	featureName -> "test1"
}

```